### PR TITLE
fix ytick label width in .plotQSep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
 script: 
   - | 
     R CMD build .
-    travis_wait 30 R CMD check MSnbase*tar.gz
+    travis_wait 30 R CMD check pRoloc*tar.gz
 
 r_github_packages:
   - MangoTheCat/visualTest

--- a/R/qsep.R
+++ b/R/qsep.R
@@ -100,7 +100,14 @@ setMethod("levelPlot", "QSep",
     args <- pairlist(...)
     x <- qsep(obj, norm = norm)
     n <- nrow(x)
-    opar <- par(las = 1)
+
+    ## add enough space on the left for ytick labels
+    rni <- max(strwidth(rownames(x), "inch"), na.rm = TRUE)
+    mai <- par("mai")
+    mai[2] <- mai[4] + rni + 0.1
+
+    opar <- par(las = 1,
+                mai = mai)
     on.exit(par(opar))
     if (!"ylim" %in% names(args))
         boxplot(x, horizontal = TRUE,


### PR DESCRIPTION
This PR adds some extra space on the left for longer tick labels.

# before
![before](https://cloud.githubusercontent.com/assets/1828443/22671922/1b5fb6e6-ecd1-11e6-996e-489fe398f9d5.png)

# after
![after](https://cloud.githubusercontent.com/assets/1828443/22671925/1f1174dc-ecd1-11e6-8cc8-02fc723029ea.png)
