### PR TITLE
Update machinelearning-functions-PerTurbo.R

### DIFF
--- a/R/machinelearning-functions-PerTurbo.R
+++ b/R/machinelearning-functions-PerTurbo.R
@@ -362,7 +362,7 @@ perTurboClassification <- function(object,
     tempScores[trainInd[i]] <- 1
     ## Add predicted labels
     i <- 1:length(testInd)
-    tempScores[testInd[i]] <- max(ans[i,])    
+    tempScores[testInd[i]] <- apply(ans, 1, max)
     fData(object)$perTurbo.scores <- tempScores    
   } ## else scores is "none"
   


### PR DESCRIPTION
Hello,

I don't know if it's because of the new R version but call max with i like this only return one value; as a consequence all prediction scores from perTurbo are the same for each protein with unknown location. Calling max with apply prevent from this issue.
I didn't check but it's maybe the case with other machine learning functions from pRoloc.